### PR TITLE
make: support standard CPPFLAGS to aid distro packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ all: build
 
 build:
 ifeq ($(GPIOSUPPORT), on)
-	$(CC) $(CFLAGS) -o hcxpioff hcxpioff.c $(LDFLAGS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -o hcxpioff hcxpioff.c $(LDFLAGS)
 endif
 ifeq ($(HOSTOS), Linux)
-	$(CC) $(CFLAGS) -o hcxdumptool hcxdumptool.c -lpthread $(LDFLAGS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -o hcxdumptool hcxdumptool.c -lpthread $(LDFLAGS)
 endif
 
 


### PR DESCRIPTION
Make by default supports CPPFLAGS as well, adding them to the custom
targets aids distro packaging as they define certain things in CPPFLAGS.