### PR TITLE
Generate a random bssid/mac with unicast bit 0 and global unique

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -4484,7 +4484,7 @@ mac_mybcap[4] = (mynicap >> 8) & 0xff;
 mac_mybcap[3] = (mynicap >> 16) & 0xff;
 mac_mybcap[2] = myouiap & 0xff;
 mac_mybcap[1] = (myouiap >> 8) & 0xff;
-mac_mybcap[0] = (myouiap >> 16) & 0xff;
+mac_mybcap[0] = (myouiap >> 16) & 0xfc;
 memcpy(&mac_myap, &mac_mybcap, 6);
 
 if(myouista == 0)


### PR DESCRIPTION
The first octet LSB bit determines if the mac is a unicast (0) or multicast (1)
The first octet Second LSB bit determines if the mac is global unique (0) or locally administered (1)
https://en.wikipedia.org/wiki/MAC_address#/media/File:MAC-48_Address.svg

Having those bits set can raise suspicion, the locally administered sometimes are used by enterprise access points though.