### PR TITLE
Add new option --eapreq to send EAP Requests to WPA-Enterprise clients

### DIFF
--- a/include/hcxdumptool.h
+++ b/include/hcxdumptool.h
@@ -34,6 +34,7 @@
 #define HCX_STATUS			34
 #define HCX_BEACONPARAMS		35
 #define HCX_WPAENT              	36
+#define HCX_EAPREQ                  37
 #define HCX_INTERFACE_NAME		'i'
 #define HCX_PCAPNG_NAME			'o'
 #define HCX_PACPNG_FRAMES		'f'
@@ -52,6 +53,9 @@
 #define RGLIST_MAX		1024
 #define OWNLIST_MAX		1024
 #define PMKLIST_MAX		1024
+
+#define EAPLIST_MAX     1024
+#define EAPREQLIST_MAX  20
 
 #define SCANLIST_MAX		256
 #define FILTERLIST_MAX		256
@@ -187,6 +191,7 @@ typedef struct
  uint8_t		client[6];
  uint8_t		essidlen;
  uint8_t		essid[ESSID_LEN_MAX];
+ uint8_t        eapreqstate;
 
 }ownlist_t;
 #define	OWNLIST_SIZE (sizeof(ownlist_t))
@@ -300,4 +305,15 @@ if(ia->count < ib->count) return 1;
 else if(ia->count > ib->count) return -1;
 return 0;
 }
+/*===========================================================================*/
+typedef struct
+{
+uint8_t         termination;
+#define EAPREQLIST_DEAUTH 0xfe
+#define EAPREQLIST_NOTERM 0xff
+uint16_t        length;
+uint8_t         type;
+uint8_t         data[EAP_LEN_MAX];
+}eapreqlist_t;
+#define EAPREQLIST_SIZE (sizeof(eapreqlist_t))
 /*===========================================================================*/

--- a/include/hcxdumptool.h
+++ b/include/hcxdumptool.h
@@ -76,6 +76,7 @@
 #define RSN_LEN_MIN		20
 #define WPA_LEN_MIN		22
 #define BEACONBODY_LEN_MAX	2301
+#define EAP_LEN_MAX 1418
 
 #define IESETLEN_MAX 50
 


### PR DESCRIPTION
This function sends out arbitrary EAP Requests that are given as comma separated hex strings with an optional termination flag.
- the EAP Request sequence is send out for every network that is associated as a WPA-Enterprise network by the client
- every response by the client to a request is responded to by a default or choosen terminating EAP status, client deauthentication or no packet
- if the sequence is interrupted and the client reconnects using the same ESSID, the sequence will be resumed
- the EAP Request sequence is reset every time the client associates with a different ESSID
- WPA-PSK associations are handled as usual

Caveats when using this function:
- clients will be authenticated every time they request, even if their status suggests they would be ignored otherwise
- clients with more than one network configured for WPA-Enterprise are probed with the EAP Request sequence every time they associate using a different ESSID

`--eapreq=<type><data>[:<term>],... : send max. 20 subsequent EAP requests after initial EAP ID request, hex string starting with EAP Type`
`          response is terminated with :F = EAP Failure, :S = EAP Success, :I = EAP ERP Initiate, :F = EAP ERP Finish,`
`          :D = Deauthentication, :- = no packet`
`          default behavior is terminating all responses with a Failure packet, after last one the client is deauthenticated`