### PR TITLE
Add ALFA AWUS036ACH to list of supported wifi adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ This list is for information purposes only and should not be regarded as a bindi
 | TP-LINK Archer T2UH     | ID 148f:761a Ralink Technology, Corp. MT7610U ("Archer T2U" 2.4G+5G WLAN Adapter) |
 | ASUS USB-AC51           | ID 0b05:17d1 ASUSTek Computer, Inc. AC51 802.11a/b/g/n/ac Wireless Adapter [Mediatek MT7610U] |
 | ALFA AWUS036ACM         | ID 0e8d:7612 MediaTek Inc. MT7612U 802.11a/b/g/n/ac Wireless Adapter |
+| ALFA AWUS036ACH         | ID 0bda:8812 Realtek Semiconductor Corp. RTL8812AU 802.11a/b/g/n/ac 2T2R DB WLAN Adapter <br /> Required driver: https://github.com/aircrack-ng/rtl8812au - interface must be set to monitor mode manually using iw before starting hcxdumptool |
 | CSL 300MBit 300649      | ID 148f:5572 Ralink Technology, Corp. RT5572 Wireless Adapter |
 | EDIMAX EW-7711UAN       | ID 7392:7710 Edimax Technology Co., Ltd |
 | TENDA W311U+            | ID 148f:3070 Ralink Technology, Corp. RT2870/RT3070 Wireless Adapter |


### PR DESCRIPTION
I have been using this interface with hcxdumptool for some time already and never had any issues. It requires you to run "iw dev \<interface\> set type monitor" before starting hcxdumptool or packet injection won't work, but other than that, it works fine. I've only tested it with the [aircrack-ng rtl8812au driver](https://github.com/aircrack-ng/rtl8812au) on 5.10.41-1-MANJARO but I don't think there will be issues on other distros. If this gets merged, I will also add it in the [Wiki section](https://github.com/ZerBea/hcxdumptool/wiki/WiFi-Adapters).