### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,14 @@ DEFS		= -DVERSION_TAG=\"$(VERSION_TAG)\" -DVERSION_YEAR=\"$(VERSION_YEAR)\"
 
 INSTALL		?= install
 INSTFLAGS	=
+PKG_CONFIG ?= pkg-config
 
 ifeq ($(HOSTOS), Linux)
 INSTFLAGS += -D
 endif
 
-OPENSSL_LIBS=$(shell pkg-config --libs openssl)
-OPENSSL_CFLAGS=$(shell pkg-config --cflags openssl)
+OPENSSL_LIBS=$(shell $(PKG_CONFIG) --libs openssl)
+OPENSSL_CFLAGS=$(shell $(PKG_CONFIG) --cflags openssl)
 
 TOOLS=
 TOOLS+=hcxdumptool


### PR DESCRIPTION
Hcxdumptool fails to cross build from source, because Makefile hard codes the build architecture pkg-config and thus fails
finding required libraries. Please consider applying the attached patch
to make it substitutable.