### PR TITLE
Added dynamic rpi gpio base

### DIFF
--- a/hcxpioff.c
+++ b/hcxpioff.c
@@ -102,7 +102,7 @@ if(fd_mem < 0)
 	fprintf(stderr, "failed to get device memory\n");
 	return false;
 	}
-gpio_map = mmap(NULL, BLOCK_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED, fd_mem, GPIO_BASE +gpioperi);
+gpio_map = mmap(NULL, BLOCK_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED, fd_mem, gpioperi);
 close(fd_mem);
 if(gpio_map == MAP_FAILED)
 	{
@@ -113,84 +113,50 @@ gpio = (volatile unsigned *)gpio_map;
 return true;
 }
 /*===========================================================================*/
-static int getrpirev()
+static inline int getgpiobasemem()
 {
-static FILE *fh_rpi;
+static FILE *cpuinfo;
+static FILE *iomem;
 static int len;
 static int rpi = 0;
-static int rev = 0;
 static int gpioperibase = 0;
-static char *revptr = NULL;
-static const char *revstr = "Revision";
-static const char *hwstr = "Hardware";
-static const char *snstr = "Serial";
 static char linein[128];
+static int str_length;
+static char* str_start;
+static char* str_end;
+static char* buf;
 
-fh_rpi = fopen("/proc/cpuinfo", "r");
-if(fh_rpi == NULL)
-	{
+cpuinfo = fopen("/proc/cpuinfo", "r");
+if(cpuinfo == NULL)
+{
 	perror("failed to retrieve cpuinfo");
+	return gpioperibase;
+}
+while(1)
+	{
+	if((len = fgetline(cpuinfo, 128, linein)) == -1) break;
+	if(strstr(linein, "Raspberry Pi"))
+			rpi = true;
+	}
+if (!rpi) return gpioperibase;
+iomem = fopen("/proc/iomem", "r");
+if(iomem == NULL)
+	{
+	perror("failed to retrieve iomem");
 	return gpioperibase;
 	}
 while(1)
 	{
-	if((len = fgetline(fh_rpi, 128, linein)) == -1) break;
-	if(len < 15) continue;
-	if(memcmp(&linein, hwstr, 8) == 0)
-		{
-		rpi |= 1;
-		continue;
-		}
-	if(memcmp(&linein, revstr, 8) == 0)
-		{
-		rpirevision = strtol(&linein[len -6], &revptr, 16);
-		if((revptr - linein) == len)
+	if((len = fgetline(iomem, 128, linein)) == -1) break;
+	if((str_end = strstr(linein, ".gpio")))
 			{
-			rev = (rpirevision >> 4) &0xff;
-			if(rev <= 3)
-				{
-				gpioperibase = GPIO_PERI_BASE_OLD;
-				rpi |= 2;
-				continue;
-				}
-			if(rev == 0x09)
-				{
-				gpioperibase = GPIO_PERI_BASE_OLD;
-				rpi |= 2;
-				continue;
-				}
-			if(rev == 0x0c)
-				{
-				gpioperibase = GPIO_PERI_BASE_OLD;
-				rpi |= 2;
-				continue;
-				}
-			if((rev == 0x04) || (rev == 0x08) || (rev == 0x0d) || (rev == 0x00e) || (rev == 0x011))
-				{
-				gpioperibase = GPIO_PERI_BASE_NEW;
-				rpi |= 2;
-				continue;
-				}
-			continue;
+			str_start = strstr(linein, ":") + 2;
+			str_length = str_end - str_start;
+			buf = (char*)malloc(str_length);
+			strncpy(buf, str_start, str_length);
+			gpioperibase = strtoll(buf, NULL, 16);
 			}
-		rpirevision = strtol(&linein[len -4], &revptr, 16);
-		if((revptr - linein) == len)
-			{
-			if((rpirevision < 0x02) || (rpirevision > 0x15)) continue;
-			if((rpirevision == 0x11) || (rpirevision == 0x14)) continue;
-			gpioperibase = GPIO_PERI_BASE_OLD;
-			rpi |= 2;
-			}
-		continue;
-		}
-	if(memcmp(&linein, snstr, 6) == 0)
-		{
-		rpi |= 4;
-		continue;
-		}
 	}
-fclose(fh_rpi);
-if(rpi < 0x7) return 0;
 return gpioperibase;
 }
 /*===========================================================================*/
@@ -207,7 +173,7 @@ if((gpiobutton > 0) || (gpiostatusled > 0))
 		fprintf(stderr, "same value for wpi_button and wpi_statusled is not allowed\n");
 		return false;
 		}
-	gpiobasemem = getrpirev();
+	gpiobasemem = getgpiobasemem();
 	if(gpiobasemem == 0)
 		{
 		fprintf(stderr, "failed to locate GPIO\n");

--- a/include/rpigpio.h
+++ b/include/rpigpio.h
@@ -1,8 +1,5 @@
 #define GPIO_LED_DELAY	100000000
 
-#define GPIO_PERI_BASE_OLD	0x20000000
-#define GPIO_PERI_BASE_NEW	0x3F000000
-#define GPIO_BASE		0x200000
 #define PAGE_SIZE		(4*1024)
 #define BLOCK_SIZE		(4*1024)
 
@@ -12,6 +9,5 @@
 #define GPIO_CLR *(gpio +10)
 #define GET_GPIO(g) (*(gpio +13) & (1 << g))
 
-static int rpirevision;
 static void *gpio_map;
 static volatile unsigned *gpio;


### PR DESCRIPTION
Using my Raspberry Pi 4, setting the `--gpio_button` and `--gpio_statusled` arguments was not working properly. I was not getting any errors, but the button and LED was not working as intended. I was sure my wiring was correct.

I found that the `GPIO_PERI_BASE_NEW` hard-coded address was incorrect, being set to `0x3F000000` while `0xFE000000` was the correct address for my rpi. It also seems like this is not the first time this has happened, with another variable called `GPIO_PERI_BASE_OLD` and some program logic to check which base address to use.

Instead of keeping track of the different GPIO base addresses that varying revisions of Raspberry Pis may have, `/proc/iomem` can be read and parsed directly as it contains the address.

Changes have been tested on a Raspberry Pi 4 Model B Rev 1.1 and Raspberry Pi 3 Model B Rev 1.2, other models and revisions may need additional testing.