### PR TITLE
Fix WEXT verification on some devices

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -7099,7 +7099,7 @@ if(ioctl(fd_socket, SIOCGIWNAME, &iwr) < 0)
 	perror("failed to detect wlan interface");
 	return false;
 	}
-if(strncmp(protocol80211, iwr.u.name, IF_NAMESIZE) != 0) fprintf(stderr, "warning this driver does not support WIRELESS EXTENSIONS\nplease try hcxlabtool: https://github.com/ZerBea/wifi_laboratory\n");
+if(memcmp(protocol80211, iwr.u.name, strlen(protocol80211)) != 0) fprintf(stderr, "warning this driver does not support WIRELESS EXTENSIONS\nplease try hcxlabtool: https://github.com/ZerBea/wifi_laboratory\n");
 memcpy(&interfaceprotocol, iwr.u.name, IFNAMSIZ);
 if(bpf.len > 0)
 	{


### PR DESCRIPTION
On my rtl8814a adapter, iwr.u.name is "IEEE 802.11AC" (or disabling the 5ghz band will appear as "IEEE 802.11bgn"). Using IF_NAMESIZE, a maximum of 16 chars (null termination) is compared.