### PR TITLE
fix typo in targetscan MAC size error message

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -9030,7 +9030,7 @@ while((auswahl = getopt_long(argc, argv, short_options, long_options, &index)) !
 		l= strlen(optarg);
 		if((l < 12) || (l > 17))
 			{
-			fprintf(stderr, "error wrong MAC size %s (alowed: 112233445566, 11:22:33:44:55:66, 11-22-33-44-55-66)\n", optarg);
+			fprintf(stderr, "error wrong MAC size %s (allowed: 112233445566, 11:22:33:44:55:66, 11-22-33-44-55-66)\n", optarg);
 			exit(EXIT_FAILURE);
 			}
 		p2 = 0;


### PR DESCRIPTION
While experimenting with this fantastic tool I noticed a typo in a `--do_targetscan=` error message which I fixed now:

```
$ sudo ./hcxdumptool -i wlp0s20f0u1 --do_targetscan=xx:xx:xx:xx:xx:xxx
error wrong MAC size xx:xx:xx:xx:xx:xxx (alowed: 112233445566, 11:22:33:44:55:66, 11-22-33-44-55-66)
```

'alowed' --> 'allowed'