### PR TITLE
extend 'make install' instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,20 @@ Solve dependencies
 as mentioned in Requirements chapter
 
 
-Compile
+Compile & install
 --------------
 ```
 make
+```
+
+install to `/usr/bin`:
+```
 make install (as super user)
+```
+
+or install to `/usr/local/bin`:
+```
+make install PREFIX=/usr/local (as super user)
 ```
 
 Or install via packet manager


### PR DESCRIPTION
Same as https://github.com/ZerBea/hcxtools/pull/256 just for this repo.

```
$ sudo make install PREFIX=/usr/local                  
install -D -m 0755 hcxdumptool /usr/local/bin/hcxdumptool
install -D -m 0755 hcxpioff /usr/local/bin/hcxpioff
```