### PR TITLE
remove deprecated hcxpioff from .gitignore, manpage and readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 hcxdumptool
-hcxpioff

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Detailed description
 | Tool           | Description                                                                                            |
 | -------------- | ------------------------------------------------------------------------------------------------------ |
 | hcxdumptool    | Tool to run several tests to determine if ACCESS POINTs or CLIENTs are vulnerable                      |
-| hcxpioff       | Turns Raspberry Pi off via GPIO switch                                                                 |
 
 
 Work flow

--- a/man/hcxdumptool.1
+++ b/man/hcxdumptool.1
@@ -8,7 +8,6 @@ Small tool to capture packets from wlan devices and to detect weak points within
 .SH TOOLS
 .nf
 | hcxdumptool    | Tool to run several tests to determine if ACCESS POINTs or CLIENTs are vulnerable                      |
-| hcxpioff       | Turns Raspberry Pi off via GPIO switch                                                                 |
 .SH OPTIONS
 help menu (-h or --help) of each tool will list all available options
 .SH RELATED TOOLS


### PR DESCRIPTION
`hcxpioff.c` has been removed in https://github.com/ZerBea/hcxdumptool/commit/311e09325d70a0774d25f687b285c3af26ca7519, lets update `.gitignore`, `manpage` and `README.md` also