### PR TITLE
update Debian package requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Or install via package manager
 
 ### Debian (e.g. Kali, Ubuntu) release requirements >= bookworm (testing/Debian 12)  
 To install use the following:  
-`apt-get install pkg-config libcurl4-openssl-dev libssl-dev zlib1g-dev make gcc`
+`apt-get install make gcc`
 
 
 Compile for Android


### PR DESCRIPTION
`pkg-config` `libcurl4-openssl-dev` `libssl-dev` are not necessary anymore (since https://github.com/ZerBea/hcxdumptool/commit/d1f23265349bae552659e964cfb7f2953548d93a and https://github.com/ZerBea/hcxdumptool/commit/311e09325d70a0774d25f687b285c3af26ca7519), `zlib1g-dev` has never been required, I think it was just copied from `hcxtools`, so lets remove them.