### PR TITLE
remove NETLINK from unsupported list

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Read this post: Hash mode 22000 explained (https://hashcat.net/forum/thread-1025
 
 Read this wiki: https://hashcat.net/wiki/doku.php?id=cracking_wpawpa2
 
-Unsupported: Windows OS, macOS, Android, emulators or wrappers and NETLINK!
+Unsupported: Windows OS, macOS, Android, emulators or wrappers!
 
 
 Detailed description


### PR DESCRIPTION
`NETLINK` is supported since https://github.com/ZerBea/hcxdumptool/commit/311e09325d70a0774d25f687b285c3af26ca7519, lets update the readme