### PR TITLE
fix errorcountmax usage and error message

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -4560,7 +4560,7 @@ while((auswahl = getopt_long(argc, argv, short_options, long_options, &index)) !
 		case HCX_ERROR_MAX:
 		if((errorcountmax = strtoul(optarg, NULL, 10)) < 1)
 			{
-			fprintf(stderr, "time out timer must be > 0\n");
+			fprintf(stderr, "error counter must be > 0\n");
 			exit(EXIT_FAILURE);
 			}
 		break;

--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -2543,7 +2543,7 @@ sleepled.tv_sec = 0;
 sleepled.tv_nsec = GPIO_LED_DELAY;
 while(!wanteventflag)
 	{
-	if(errorcount > ERROR_MAX) wanteventflag |= EXIT_ON_ERROR;
+	if(errorcount > errorcountmax) wanteventflag |= EXIT_ON_ERROR;
 	epret = epoll_pwait(fd_epoll, events, epi, timerwaitnd, NULL);
 	if(epret == -1)
 		{
@@ -2628,7 +2628,7 @@ sleepled.tv_sec = 0;
 sleepled.tv_nsec = GPIO_LED_DELAY;
 while(!wanteventflag)
 	{
-	if(errorcount > ERROR_MAX) wanteventflag |= EXIT_ON_ERROR;
+	if(errorcount > errorcountmax) wanteventflag |= EXIT_ON_ERROR;
 	epret = epoll_pwait(fd_epoll, events, epi, timerwaitnd, NULL);
 	if(epret == -1)
 		{


### PR DESCRIPTION
`errorcountmax` is unsued currently meaning the value set with `--errormax=` is ignored and `ERROR_MAX` is hardcoded instead. Now this is fixed. The error message displayed when an incorrect value is set with `--errormax=` is also fixed.