### PR TITLE
fix typo in holdtime error message

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -4534,7 +4534,7 @@ while((auswahl = getopt_long(argc, argv, short_options, long_options, &index)) !
 		case HCX_HOLD_TIME:
 		if((timehold = strtoull(optarg, NULL, 10)) < 2)
 			{
-			fprintf(stderr, "hold time must be > 2 secondsn");
+			fprintf(stderr, "hold time must be > 2 seconds");
 			exit(EXIT_FAILURE);
 			}
 		timehold *= 1000000000ULL;


### PR DESCRIPTION
```
$ sudo ./hcxdumptool -i wlp0s20f0u1 -t 1                
hold time must be > 2 secondsn
```

'secondsn' --> 'seconds'