### PR TITLE
fix 5G channel to frequency conversion

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -584,8 +584,7 @@ switch(band)
 	break;
 
 	case NL80211_BAND_5GHZ:
-	if(channel >= 182 && channel <= 196) return 4000 + (channel * 5);
-	else return 5000 + channel * 5;
+	return 5000 + channel * 5;
 	break;
 
 	case NL80211_BAND_6GHZ:


### PR DESCRIPTION
This does not make sense to me:
```
	case NL80211_BAND_5GHZ:
	if(channel >= 182 && channel <= 196) return 4000 + (channel * 5);
```

If I look at [List_of_WLAN_channels#5_GHz](https://en.wikipedia.org/wiki/List_of_WLAN_channels#5_GHz_(802.11a/h/j/n/ac/ax)) all of the 5G channels can be converted to f with the same formula:
```
5000 + channel * 5;
```

According to the current implementation if I calculate f for channel 182 for example:
```
4000 + (channel * 5) = 4000 + (182 * 5) = 4910
```
but according the link above f should be 5910. But maybe just my 802.11 knowledge not good enough, please enlighten me in this case.