### PR TITLE
make error message more obvious when --nmea_dev= + --gpsd are specified

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -4645,7 +4645,7 @@ while((auswahl = getopt_long(argc, argv, short_options, long_options, &index)) !
 		case HCX_NMEA0183:
 		if(gpsdflag == true)
 			{
-			fprintf(stderr, "not allowed in combination with gpsd\n");
+			fprintf(stderr, "nmea_dev not allowed in combination with gpsd\n");
 			exit(EXIT_FAILURE);
 			}
 		nmea0183name = optarg;
@@ -4654,7 +4654,7 @@ while((auswahl = getopt_long(argc, argv, short_options, long_options, &index)) !
 		case HCX_GPSD:
 		if(nmea0183name != NULL)
 			{
-			fprintf(stderr, "not allowed in combination nmea_dev\n");
+			fprintf(stderr, "gpsd not allowed in combination with nmea_dev\n");
 			exit(EXIT_FAILURE);
 			}
 		gpsdflag = true;


### PR DESCRIPTION
For new users it might not be obvious which option is not compatible with `--nmea_dev=`/`--gpsd` if there is a lot of command line options specified at the same time:
```
$ sudo ./hcxdumptool -i wlp0s20f0u1 --gpsd --nmea_dev=/dev/ttyACM0 --gpio_button=4 --gpio_statusled=17 --onsigterm=exit --ongpiobutton=poweroff --ontot=reboot --onerror=reboot --onwatchdog=reboot --bpf=protect.bpfc --essidlist=standard.essidliste --attemptapmax=1000
not allowed in combination with gpsd
```
so I made it more clear:
```
$ sudo ./hcxdumptool -i wlp0s20f0u1 --nmea_dev=/dev/ttyACM0 --gpsd
gpsd not allowed in combination with nmea_dev
                                                                                                                      
$ sudo ./hcxdumptool -i wlp0s20f0u1 --gpsd --nmea_dev=/dev/ttyACM0
nmea_dev not allowed in combination with gpsd
```
