### PR TITLE
exit always when read_bpf() fails

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -4080,7 +4080,7 @@ while(c < bpf.len)
 	bpfptr++;
 	c++;
 	}
-if(bpf.len != c) fprintf(stderr, "failed to read Berkeley Packet Filter\n");
+if(bpf.len != c) return false;
 fclose(fh_filter);
 return true;
 }


### PR DESCRIPTION
I think in `read_bpf()` we should return `false` on all errors and let `open_socket_rx()` handle the return value:

```
static bool read_bpf(char *bpfname)
{
...

if((fh_filter = fopen(bpfname, "r")) == NULL) return false;
if((len = fgetline(fh_filter, 128, linein)) < 0) return false;
sscanf(linein, "%"SCNu16, &bpf.len);
if(bpf.len == 0) return false;
bpf.filter = (struct sock_filter*)calloc(bpf.len, sizeof(struct sock_filter));
c = 0;
bpfptr = bpf.filter;
while(c < bpf.len)
	{
	if((len = fgetline(fh_filter, 128, linein)) == -1)
		{
		bpf.len = 0;
		break;
		}
	sscanf(linein, "%" SCNu16 "%" SCNu8 "%" SCNu8 "%" SCNu32, &bpfptr->code, &bpfptr->jt, &bpfptr->jf, &bpfptr->k);
	bpfptr++;
	c++;
	}
if(bpf.len != c) return false;
fclose(fh_filter);
return true;
}
```
```
static bool open_socket_rx(char *bpfname)
{
...
if(bpfname != NULL)
	{
	if(read_bpf(bpfname) == false)
		{
		errorcount++;
		fprintf(stderr, "failed to read BPF\n");
		return false;
		}
	}
...
```

Currently in case of some corrupt BPFs this can happen:
```
$ cat protect.bpf 
10
10
```
```
$ sudo ./hcxdumptool -i wlp0s20f0u1 --bpf=protect.bpf

Requesting interface capabilities. This may take some time.
Please be patient...


interface information:
...
failed to read Berkeley Packet Filter

This is a highly experimental penetration testing tool!
It is made to detect vulnerabilities in your NETWORK mercilessly!

BPF is unset! Make sure hcxdumptool is running in a 100% controlled environment!

Initialize main scan loop...^C
bye-bye
```
After the modification:
```
$ sudo ./hcxdumptool -i wlp0s20f0u1 --bpf=protect.bpf

Requesting interface capabilities. This may take some time.
Please be patient...


interface information:

...
failed to read BPF
failed to open raw packet socket

2 errors during runtime

bye-bye
```