### PR TITLE
update procedure in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Procedure
 
 first run hcxdumptool -L to get information about suitable interfaces
 
-run hcxdumptool --rca_scan to retrieve information about access points
+run hcxdumptool [-i \<interface\>] [--rcascan_passive] to retrieve information about access points
 
 
 pcapng option codes (Section Header Block)


### PR DESCRIPTION
Updated obsolete chapter 'procedure' in the readme.

```
$ sudo ./hcxdumptool -i wlp0s20f0u1 --rca_scan       
./hcxdumptool: unrecognized option '--rca_scan'
hcxdumptool 6.2.9 (C) 2023 by ZeroBeat
usage: hcxdumptool -h for help

```