### PR TITLE
add void keyword to process_nmea0183()

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -2323,7 +2323,7 @@ return;
 /*===========================================================================*/
 /*===========================================================================*/
 #ifdef NMEAOUT
-static inline __attribute__((always_inline)) void process_nmea0183()
+static inline __attribute__((always_inline)) void process_nmea0183(void)
 {
 static char *nmeaptr;
 static const char *gprmcid = "$GPRMC,";


### PR DESCRIPTION
I am playing with the NMEA code currently. This is a follow-up of #272 where `void` has been added to the function definitions but `process_nmea0183()` has been left out.