### PR TITLE
exit if NMEA or GPSD open fails

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -4764,6 +4764,7 @@ if(nmea0183name != NULL)
 		{
 		errorcount++;
 		fprintf(stderr, "failed to open NMEA0183 device\n");
+		goto byebye;
 		}
 	}
 if(gpsdflag == true)
@@ -4772,6 +4773,7 @@ if(gpsdflag == true)
 		{
 		errorcount++;
 		fprintf(stderr, "failed to connect to GPSD\n");
+		goto byebye;
 		}
 	}
 #endif


### PR DESCRIPTION
Is there any specific reason not to exit when NMEA or GPSD open fails?

Currently `hcxdumptool` still starts, prints a warning message though but it happens fast so we (at least me) might not always notice it:
```
$ sudo ./hcxdumptool -i wlp0s20f0u1u2 --nmea_dev=/dev/ttyACM0

Requesting interface capabilities. This may take some time.
Please be patient...

failed to open NMEA0183 device

interface information:

...

This is a highly experimental penetration testing tool!
It is made to detect vulnerabilities in your NETWORK mercilessly!

BPF is unset! Make sure hcxdumptool is running in a 100% controlled environment!

Initialize main scan loop...^C
1 errors during runtime

bye-bye
```

I think exit would be better:
```
$ sudo ./hcxdumptool -i wlp0s20f0u1u2 --nmea_dev=/dev/ttyACM0

Requesting interface capabilities. This may take some time.
Please be patient...

failed to open NMEA0183 device

1 errors during runtime

bye-bye
```