### PR TITLE
android cleanup

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,9 +1,18 @@
 LOCAL_PATH:=$(call my-dir)
 
-HCX_CFLAGS:=-std=gnu99 -O3 -Wall -Wextra
+ifeq ($(PRODUCTION),1)
+VERSION_TAG		:= $(PRODUCTION_VERSION)
+else
+VERSION_TAG		:= $(shell git describe --tags || echo $(PRODUCTION_VERSION))
+endif
+VERSION_YEAR	:= $(shell echo $(PRODUCTION_YEAR))
+
+HCX_CFLAGS		:= -std=gnu99 -O3 -Wall -Wextra
+HCX_DEFS		:= -DVERSION_TAG=\"$(VERSION_TAG)\" -DVERSION_YEAR=\"$(VERSION_YEAR)\"
+HCX_DEFS		+= -DSTATUSOUT -DNMEAOUT
 
 include $(CLEAR_VARS)
 LOCAL_MODULE			:= hcxdumptool
-LOCAL_CFLAGS			+= $(HCX_CFLAGS)
+LOCAL_CFLAGS			+= $(HCX_CFLAGS) $(HCX_DEFS)
 LOCAL_SRC_FILES			:= hcxdumptool.c
 include $(BUILD_EXECUTABLE)

--- a/README.md
+++ b/README.md
@@ -118,12 +118,41 @@ To install use the following:
 Compile for Android
 --------------
 
-You need:
-* Android NDK installed in your system and in path variable
+Install [Android NDK](https://developer.android.com/ndk/downloads) on your system and add it to `PATH`:
+```
+$ ndk-build --version
+GNU Make 4.3
+Built for x86_64-pc-linux-gnu
+Copyright (C) 1988-2020 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+```
 
-* This repository cloned with all submodules (`--recursive` flag in `git clone` or `git submodules update` command run)
-
-Just run `ndk-build` - built executables for some architectures should be created inside `libs` directory.
+Run `ndk-build` - built executables for some architectures will be created inside `libs` directory:
+```
+$ ndk-build
+[arm64-v8a] Compile        : hcxdumptool <= hcxdumptool.c
+...
+70 warnings generated.
+[arm64-v8a] Executable     : hcxdumptool
+[arm64-v8a] Install        : hcxdumptool => libs/arm64-v8a/hcxdumptool
+[armeabi-v7a] Compile thumb  : hcxdumptool <= hcxdumptool.c
+...
+82 warnings generated.
+[armeabi-v7a] Executable     : hcxdumptool
+[armeabi-v7a] Install        : hcxdumptool => libs/armeabi-v7a/hcxdumptool
+[x86] Compile        : hcxdumptool <= hcxdumptool.c
+...
+82 warnings generated.
+[x86] Executable     : hcxdumptool
+[x86] Install        : hcxdumptool => libs/x86/hcxdumptool
+[x86_64] Compile        : hcxdumptool <= hcxdumptool.c
+...
+70 warnings generated.
+[x86_64] Executable     : hcxdumptool
+[x86_64] Install        : hcxdumptool => libs/x86_64/hcxdumptool
+```
 Copy it to your phone and enjoy.
 
 


### PR DESCRIPTION
Android build was broken so I fixed it, readme was obsolete so it is also updated:

Submodule `include/android-ifaddrs` has been dropped in https://github.com/ZerBea/hcxdumptool/commit/311e09325d70a0774d25f687b285c3af26ca7519 so an empty `.gitmodules` has been left behind. Now it is also dropped, and readme is updated: no recursive clone is necessary anymore since this was the only submodule. Build instructions has been made more verbose as well. I did not test any of the built executables though because I am not interested in that.