### PR TITLE
fix implicit declaration Android build warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,22 +134,22 @@ Run `ndk-build` - built executables for some architectures will be created insid
 $ ndk-build
 [arm64-v8a] Compile        : hcxdumptool <= hcxdumptool.c
 ...
-70 warnings generated.
+1 warning generated.
 [arm64-v8a] Executable     : hcxdumptool
 [arm64-v8a] Install        : hcxdumptool => libs/arm64-v8a/hcxdumptool
 [armeabi-v7a] Compile thumb  : hcxdumptool <= hcxdumptool.c
 ...
-82 warnings generated.
+13 warnings generated.
 [armeabi-v7a] Executable     : hcxdumptool
 [armeabi-v7a] Install        : hcxdumptool => libs/armeabi-v7a/hcxdumptool
 [x86] Compile        : hcxdumptool <= hcxdumptool.c
 ...
-82 warnings generated.
+13 warnings generated.
 [x86] Executable     : hcxdumptool
 [x86] Install        : hcxdumptool => libs/x86/hcxdumptool
 [x86_64] Compile        : hcxdumptool <= hcxdumptool.c
 ...
-70 warnings generated.
+1 warning generated.
 [x86_64] Executable     : hcxdumptool
 [x86_64] Install        : hcxdumptool => libs/x86_64/hcxdumptool
 ```

--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -39,6 +39,10 @@
 #include "include/radiotap.h"
 #include "include/ieee80211.h"
 #include "include/pcapng.h"
+#ifdef __ANDROID__
+#include <libgen.h>
+#include <unistd.h>
+#endif
 /*===========================================================================*/
 /*
 static void debugprint();


### PR DESCRIPTION
There are a lot of warnings going on in the Android builds but luckily most of them are implicit declarations:
```
./hcxdumptool.c:638:4: warning: implicit declaration of function 'write' is invalid in C99 [-Wimplicit-function-declaration]
if(write(fd_hcxpos, gprmc, gprmclen) != gprmclen) errorcount++;
   ^
...
./hcxdumptool.c:3033:19: warning: implicit declaration of function 'basename' is invalid in C99 [-Wimplicit-function-declaration]
                                        drivername = basename(driverlink);
                                                     ^
```
and can be easily fixed by including the proper headers.

The remaining ones are:
```
./hcxdumptool.c:1157:20: warning: unused function 'send_80211_authenticationrequestnoack' [-Wunused-function]
static inline void send_80211_authenticationrequestnoack(void)
                   ^
...
./hcxdumptool.c:2808:42: warning: comparison of integers of different signs: '__u32' (aka 'unsigned int') and 'ssize_t' (aka 'int') [-Wsign-compare]
        for(nlh = (struct nlmsghdr*)nlrxbuffer; NLMSG_OK(nlh, msglen); nlh = NLMSG_NEXT (nlh, msglen))
                                                ^~~~~~~~~~~~~~~~~~~~~
```