### PR TITLE
add sorting info to display header

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -546,8 +546,16 @@ static char *ak;
 static char *ar;
 
 system("clear");
-sprintf(&rtb[0], "  CHA  R P M A    MAC-AP    ESSID (last seen on top)         SCAN-FREQUENCY: %6u\n"
+if (rdsort == 1)
+	{
+	sprintf(&rtb[0], "  CHA  R P M A    MAC-AP    ESSID (last PMKID/EAPOL on top)  SCAN-FREQUENCY: %6u\n"
 	"------------------------------------------------------------------------------------\n", (scanlist + scanlistindex)->frequency);
+	}
+else
+	{
+	sprintf(&rtb[0], "  CHA  R P M A    MAC-AP    ESSID (last seen on top)         SCAN-FREQUENCY: %6u\n"
+	"------------------------------------------------------------------------------------\n", (scanlist + scanlistindex)->frequency);
+	}
 p = strlen(rtb);
 i = 0;
 pa = 0;


### PR DESCRIPTION
This is a follow-up of https://github.com/ZerBea/hcxdumptool/commit/2bed3d4f78b117970dfe2d15e52516c69d55589a which is a really good feature I wanted for quite some time. The display header is a bit misleading though in the current implementation and always says `ESSID (last seen on top)`, even if `--rds=1` is specified.