### PR TITLE
rca fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Procedure
 
 first run hcxdumptool -L to get information about suitable interfaces
 
-run hcxdumptool [-i \<interface\>] [--rcascan_passive] to retrieve information about access points
+run hcxdumptool [-i \<interface\>] [--rcascan=p] to retrieve information about access points
 
 
 pcapng option codes (Section Header Block)

--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -4803,7 +4803,7 @@ while((auswahl = getopt_long(argc, argv, short_options, long_options, &index)) !
 		rcascanflag = optarg;
 		if((rcascanflag[0] != 'a') && (rcascanflag[0] != 'p'))
 			{
-			fprintf(stderr, "rcascan: only (a)active or (p) passive allowed\n");
+			fprintf(stderr, "rcascan: only (a) active or (p) passive allowed\n");
 			exit(EXIT_FAILURE);
 			}
 		break;


### PR DESCRIPTION
`--rcascan_passive` is not a valid option anymore so I updated the readme. Added a missing space also the the rcascan error message.