### PR TITLE
remove unused ioctl include

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -26,7 +26,6 @@
 #include <sys/cdefs.h>
 #include <sys/epoll.h>
 #include <sys/file.h>
-#include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/time.h>
 #include <sys/timerfd.h>


### PR DESCRIPTION
`ioctl()` calls have been removed in https://github.com/ZerBea/hcxdumptool/commit/7c353a7a63d6f95f0e85522a63eb373f282b1da4 so this include is not necessary anymore.