### PR TITLE
fix init_lists() related error message

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -4848,7 +4848,7 @@ if((gpiobutton + gpiostatusled) > 0)
 if(init_lists() == false)
 	{
 	errorcount++;
-	fprintf(stderr, "failed to open control sockets\n");
+	fprintf(stderr, "failed to initialize lists\n");
 	goto byebye;
 	}
 init_values();


### PR DESCRIPTION
Fixed a copy-paste error in the `init_lists()` related error message. It is very unlikely these `calloc` calls would fail anytime but lets clean up the message anyway.