### PR TITLE
make pointer parameter rcatypeflag pointer to const

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -2711,7 +2711,7 @@ return true;
 }
 /*===========================================================================*/
 /* RCA SCAN LOOP */
-static bool nl_scanloop_rca(char *rcatypeflag)
+static bool nl_scanloop_rca(const char *rcatypeflag)
 {
 static ssize_t i;
 static int fd_epoll = 0;


### PR DESCRIPTION
`*rcatypeflag` is being read only so `const` can be added.