### PR TITLE
fix function declaration related warning

### DIFF
--- a/include/hcxdumptool.h
+++ b/include/hcxdumptool.h
@@ -333,5 +333,5 @@ typedef struct
 }req_t;
 /*===========================================================================*/
 static bool read_bpf(char *bpfname);
-static inline bool nl_set_frequency();
+static inline bool nl_set_frequency(void);
 /*===========================================================================*/


### PR DESCRIPTION
When building with `clang` we get this warning:

```
$ make CC=clang
fatal: No names found, cannot describe anything.
clang -O3 -Wall -Wextra -Wpedantic -std=gnu99   -o hcxdumptool hcxdumptool.c -DVERSION_TAG=\"6.3.2\" -DVERSION_YEAR=\"2023\" -DSTATUSOUT -DNMEAOUT
In file included from hcxdumptool.c:40:
./include/hcxdumptool.h:336:36: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
static inline bool nl_set_frequency();
                                   ^
                                    void
1 warning generated.
```

Now it is fixed.