### PR TITLE
Extend compiler version detection with clang

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -4547,10 +4547,12 @@ if(uname(&utsbuffer) == 0) fprintf(stdout, "running on Linux kernel %s\n", utsbu
 #if defined (__GLIBC__)
 fprintf(stdout, "running GNU libc version %s\n", gnu_get_libc_version());
 #endif
-#if defined (__GNUC__)
+#if defined(__clang__)
+fprintf(stdout, "compiled by clang %d.%d.%d\n", __clang_major__, __clang_minor__, __clang_patchlevel__);
+#elif defined(__GNUC__)
 fprintf(stdout, "compiled by gcc %d.%d.%d\n", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
 #else
-fprintf(stdout, "compiler (__GNUC__) is not defined\n");
+fprintf(stdout, "compiler (__clang__ / __GNUC__) is not defined\n");
 #endif
 #if defined (LINUX_VERSION_MAJOR)
 fprintf(stdout, "compiled with Linux API headers %d.%d.%d\n", LINUX_VERSION_MAJOR, LINUX_VERSION_PATCHLEVEL, LINUX_VERSION_SUBLEVEL);


### PR DESCRIPTION
Previously when compiled with `clang` the version check returned this misleading `gcc` version:

```
$ ./hcxdumptool -v
hcxdumptool 6.3.2 (C) 2023 ZeroBeat
...
compiled by gcc 4.2.1
...
```

I guess it is because `clang` defines the `__GNUC__` macros for some compatibility reasons or something like that.

I think `clang` is becoming more widespread so this case should be handled. Now, after the changes the version check is fixed:

```
$ make CC=clang                                                  
fatal: No names found, cannot describe anything.
clang -O3 -Wall -Wextra -Wpedantic -std=gnu99   -o hcxdumptool hcxdumptool.c -DVERSION_TAG=\"6.3.2\" -DVERSION_YEAR=\"2023\" -DHCXSTATUSOUT -DHCXNMEAOUT
$ ./hcxdumptool -v
...
compiled by clang 17.0.6
...
$ make clean
...
$ make
fatal: No names found, cannot describe anything.
cc -O3 -Wall -Wextra -Wpedantic -std=gnu99   -o hcxdumptool hcxdumptool.c -DVERSION_TAG=\"6.3.2\" -DVERSION_YEAR=\"2023\" -DHCXSTATUSOUT -DHCXNMEAOUT
$ ./hcxdumptool -v
...
compiled by gcc 13.2.1
..
```