### PR TITLE
Redone style of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,85 @@
-hcxdumptool
-============
+# hcxdumptool
 
 A tool to capture packets from WLAN devices and to discover potential weak points within own WiFi networks by running layer 2 attacks against the WPA protocol.
 
 Designed to to run (mostly headless) on small systems like a Raspberry Pi Zero.
 
-General Information
---------------------
+### General Information
 
-* An overview of Hashcat mode 22000. - [Hashcat Wiki](https://hashcat.net/wiki/doku.php?id=cracking_wpawpa2)
+- [An overview of Hashcat mode 22000.](https://hashcat.net/wiki/doku.php?id=cracking_wpawpa2)
 
-* A set of tools by **ZerBea** intended for processing capture files. - [hcxtools Repository](https://github.com/ZerBea/hcxtools)
+- [A set of tools by **ZerBea** intended for processing capture files.](https://github.com/ZerBea/hcxtools)
 
-* Old but still applicable write-up by **atom** of the Hashcat forums covering a new attack on WPA/WPA2 using PMKID. - [Hashcat Forum Thread](https://hashcat.net/forum/thread-7717.html)
+- [Old but still applicable write-up by **atom** of the Hashcat forums covering a new attack on WPA/WPA2 using PMKID.](https://hashcat.net/forum/thread-7717.html)
 
-* Hashcat mode 22000 write-up by **atom** of the Hashcat forums. - [Hashcat Forum Thread](https://hashcat.net/forum/thread-10253.html)
+- [Hashcat mode 22000 write-up by **atom** of the Hashcat forums.](https://hashcat.net/forum/thread-10253.html)
 
-* A write-up by **Ido Hoorvitch** from CyberArk covering the statistics of WPA/WPA2 password cracking. - [CyberArk Article](https://www.cyberark.com/resources/threat-research-blog/cracking-wifi-at-scale-with-one-simple-trick)
+- [A write-up by **Ido Hoorvitch** from CyberArk covering the statistics of WPA/WPA2 password cracking.](https://www.cyberark.com/resources/threat-research-blog/cracking-wifi-at-scale-with-one-simple-trick)
 
-* A section of this README that covers hcxdumptool's abilities and the responsibilities of using it. - [Warning!](https://github.com/ZerBea/hcxdumptool#warning)
+- [A section of this README that covers hcxdumptool's abilities and the responsibilities of using it.](https://github.com/ZerBea/hcxdumptool#warning)
 
-What Doesn't hcxdumptool Do?
------------------------------
+### What Doesn't hcxdumptool Do?
 
-* It does not crack WPA PSK related hashes. (Use Hashcat or JtR to recover the PSK.)
+- It does not crack WPA PSK related hashes. (Use Hashcat or JtR to recover the PSK.)
 
-* It does not crack WEP. (Use the aircrack-ng suite instead.)
+- It does not crack WEP. (Use the aircrack-ng suite instead.)
 
-* It does not crack WPS. (Use Reaver or Bully instead.)
+- It does not crack WPS. (Use Reaver or Bully instead.)
 
-* It does not decrypt encrypted traffic. (Use tshark or Wireshark in parallel.)
+- It does not decrypt encrypted traffic. (Use tshark or Wireshark in parallel.)
 
-* It does not record all traffic captured on the WLAN device. (Use tshark or Wireshark in parallel.)
+- It does not record all traffic captured on the WLAN device. (Use tshark or Wireshark in parallel.)
 
-* It does not perform Evil Twin attacks.
+- It does not perform Evil Twin attacks.
 
-* It does not provide a beautiful status display.
+- It does not provide a beautiful status display.
 
-* It is not a honey pot.
+- It is not a honey pot.
 
 **Unsupported:** Windows OS, macOS, Android, emulators or wrappers!
 
-Detailed Description
----------------------
+> [!NOTE]
+> **hcxdumptool** does not perform conversion or cracking! It is designed to be used in conjunction with the following tools:
+>
+> | Tool          | Description                                                                                           |
+> | ------------- | ------------------------------------------------------------------------------------------------------|
+> | hcxpcapngtool | Tool to convert raw PCAPNG files to Hashcat and JtR readable formats. (hcxtools)                      |
+> | hcxhashtool   | Tool to filter hashes from HC22000 files based on user input. (hcxtools)                              |
+> | hcxpsktool    | Tool to get weak PSK candidates from HC22000 files. (hcxtools)                                        |
+> | hcxeiutool    | Tool to calculate wordlists based off ESSIDs gathered. (hcxtools)                                     |
+> | Hashcat/JtR   | Third party tools used to infer PSK from HC22000 hash files.                                          |
 
-| Tool          | Description                                                                                           |
-| ------------- | ------------------------------------------------------------------------------------------------------|
-| hcxdumptool   | Tool to run several tests against WPA PSK to determine if ACCESS POINTs or CLIENTs are vulnerable.    |
-| hcxpcapngtool | Tool to convert raw PCAPNG files to Hashcat and JtR readable formats. (hcxtools)                      |
-| hcxhashtool   | Tool to filter hashes from HC22000 files based on user input. (hcxtools)                              |
-| hcxpsktool    | Tool to get weak PSK candidates from HC22000 files. (hcxtools)                                        |
-| hcxeiutool    | Tool to calculate wordlists based off ESSIDs gathered. (hcxtools)                                     |
-| Hashcat/JtR   | Third party tools used to infer PSK from HC22000 hash files.                                          |
-
-Work Flow
-----------
+### Work Flow
 
 hcxdumptool -> hcxpcapngtool -> hcxhashtool (additional hcxpsktool/hcxeiutool) -> Hashcat or JtR
 
-Requirements
--------------
+### Requirements
 
-* Knowledge of radio technology.
-* Knowledge of electromagnetic-wave engineering.
-* Detailed knowledge of 802.11 protocol.
-* Detailed knowledge of key derivation functions.
-* Detailed knowledge of Linux.
-* Detailed knowledge of filter procedures. (Berkeley Packet Filter, capture filter, display filter, etc.)
-* Operating system: Linux (recommended: kernel >= 6.6, mandatory: kernel >= 5.15)
-* Recommended: Arch Linux (notebooks and desktop systems), OpenWRT (small systems like Raspberry Pi, WiFi router)
-* WLAN device chipset must be able to run in monitor mode. MediaTek chipsets are preferred due to active monitor mode capabilities.
-* WLAN device driver *must* support monitor and full frame injection mode.
-* gcc >= 13 recommended (deprecated versions are not supported: https://gcc.gnu.org/)
-* make
-* libpcap and libpcap-dev (If internal BPF compiler has been enabled.)
-* Raspberry Pi A, B, A+, B+, Zero (WH). (Recommended: Zero (WH) or A+, because of a very low power consumption), but notebooks and desktops will work as well.
-* GPIO hardware mod recommended (push button and LED) on Raspberry Pi
-* To allow 5/6/7GHz packet injection, it is mandatory to uncomment a regulatory domain that support this: /etc/conf.d/wireless-regdom 
+- Knowledge of radio technology.
+- Knowledge of electromagnetic-wave engineering.
+- Detailed knowledge of 802.11 protocol.
+- Detailed knowledge of key derivation functions.
+- Detailed knowledge of Linux.
+- Detailed knowledge of filter procedures. (Berkeley Packet Filter, capture filter, display filter, etc.)
+- Operating system: Linux (recommended: kernel >= 6.6, mandatory: kernel >= 5.15)
+- Recommended: Arch Linux (notebooks and desktop systems), OpenWRT (small systems like Raspberry Pi, WiFi router)
+- WLAN device chipset must be able to run in monitor mode. MediaTek chipsets are preferred due to active monitor mode capabilities.
+- WLAN device driver *must* support monitor and full frame injection mode.
+- gcc >= 13 recommended (deprecated versions are not supported: https://gcc.gnu.org/)
+- make
+- libpcap and libpcap-dev (If internal BPF compiler has been enabled.)
+- Raspberry Pi A, B, A+, B+, Zero (WH). (Recommended: Zero (WH) or A+, because of a very low power consumption), but notebooks and desktops will work as well.
+- GPIO hardware mod recommended (push button and LED) on Raspberry Pi
+- To allow 5/6/7GHz packet injection, it is mandatory to uncomment a regulatory domain that support this: /etc/conf.d/wireless-regdom 
 
-Install Guide
---------------
+### Install Guide
 
-On most distributions, hcxdumptool and hcxtools are available through the package manager.
-
-If you decide to compile latest git head, make sure that your distribution is updated to it's latest version and make sure that all header files and dependencies have been installed!
-
-**Notice:** The packages mentioned in the "Requirements" section sometimes come under different names in a package manager! Make sure to install the correct packages!
+> [!IMPORTANT]
+> While hcxdumptool and hcxtools are available through the package manager on most distributions, these packages are usually very old and outdated, thus cloning and building is recommended. 
+>
+> Make sure that your distribution is updated to it's latest version and make sure that all header files and dependencies have been installed BEFORE attempting to compile!
+>
+> The packages mentioned in the "Requirements" section sometimes come under different names in a package manager! Make sure to install the correct packages!
 
 #### Clone Repository
 
@@ -110,36 +104,38 @@ Or install to `/usr/local/bin`:
 make install PREFIX=/usr/local (as super user)
 ```
 
-On headless operation, remove -DSTATUSOUT from the Makefile before compiling! That way, the status display will not be compiled. This will save CPU cycles and prevent ERRORs from occurring.
+> [!TIP]
+> On headless operation, remove -DSTATUSOUT from the Makefile before compiling! That way, the status display will not be compiled. This will save CPU cycles and prevent ERRORs from occurring.
+>
+> It is theoretically possible to compile hcxdumptool for other systems (e.g. Android) and other distributions (e.g. KALI) and other operating systems (BSD) as well.
+> There is no plan to support the operating systems and feature requests will be rejected.
 
-It is theoretically possible to compile hcxdumptool for other systems (e.g. Android) and other distributions (e.g. KALI) and other operating systems (BSD) as well, but there is no support and feature requests will be rejected.
+### Adapters
 
-Adapters
----------
+> [!WARNING]
+> - Do not expect flawless drivers on brand new hardware!
+>
+> - Driver must support monitor mode and full packet injection!
+>
+> - PRISM devices are _not_ supported! 
+>
+> - WIRELESS EXTENSIONS are deprecated and no longer supported!
 
-* Do not expect flawless drivers on brand new hardware!
-
-* Driver must support monitor mode and full packet injection!
-
-* No support for prism devices! 
-
-* WIRELESS EXTENSIONS are deprecated and not longer supported!
-
-Get information about VENDOR, model, chipset, and driver here: https://wikidevi.wi-cat.ru/
-
-Manufacturers do change chipsets without changing model numbers. Sometimes they add (v)ersion or (rev)vision.
-
-Preferred chipsets come from MediaTek due to active monitor mode being very reliable. (Important notice: Massive problems with MT76 USB 3.0 devices if connected to some USB 3.0 ports!)
-
-Some device and driver tests are here: https://github.com/ZerBea/hcxdumptool/discussions/361
-
-**Always verify the actual chipset with 'lsusb' and/or 'lspci'!**
-
-No support for a third party driver which is not part of the official Linux kernel (https://www.kernel.org/)
-Report related issues to the site, from which you downloaded the driver.
-
-No support for a driver which doesn't support monitor mode and full frame injection natively.
-If you need these features, do a request on www.kernel.org
+> [!NOTE]
+>
+> Manufacturers do change chipsets without changing model numbers. Sometimes they add (v)ersion or (rev)vision.
+>
+> Preferred chipsets come from MediaTek due to active monitor mode being very reliable. (Important notice: Massive problems with MT76 USB 3.0 devices if connected to some USB 3.0 ports!)
+>
+> **Always verify the actual chipset with 'lsusb' and/or 'lspci'!**
+>
+> No support for a third party driver which is not part of the official Linux kernel (https://www.kernel.org/)
+> Report related issues to the site, from which you downloaded the driver.
+>
+> No support for a driver which doesn't support monitor mode and full frame injection natively.
+> If you need these features, do a request on www.kernel.org
+>
+> Some device and driver tests can be found [here](https://github.com/ZerBea/hcxdumptool/discussions/361).
 
 Recommended WiFi chipsets:
 
@@ -148,7 +144,6 @@ Recommended WiFi chipsets:
 * Realtek (rtl8xxxu)
 
 * Ralink (rt2800usb)
-
 
 Not recommended WiFi chipsets:
 
@@ -166,8 +161,7 @@ https://wireless.wiki.kernel.org/en/users/Drivers/ath10k
 
 https://github.com/morrownr/USB-WiFi/issues/314
 
-Antennas
----------
+### Antennas
 
 The best high frequency amplifier is a good antenna!
 
@@ -181,16 +175,14 @@ It is much better to achieve gain using a good antenna instead of increasing tra
 | DELOCK 88806           | Panel           |
 | TP-LINK TL-ANT2409 A   | Panel           |
 
-GPS devices (NMEA 0183 protocol)
----------------------------------
+### GPS devices (NMEA 0183 protocol)
 
 | VENDOR MODEL                | TYPE            |
 | --------------------------- | --------------- |
 | NAVILOCK NL-701US           | USB             |
 | JENTRO BT-GPS-8 activepilot | BLUETOOTH       |
 
-Useful Scripts
----------------
+### Useful Scripts
 
 | Script       | Description                                              |
 | ------------ | -------------------------------------------------------- |
@@ -198,17 +190,7 @@ Useful Scripts
 | startnm      | Example script to stop NetworkManager                    |
 | startnlmon   | Example script to activate NETLINK monitor               |
 
-Hardware Mod - See Docs gpiowait.png (hcxdumptool)
----------------------------------------------------
-
-When using this hardware modification, the LED will flash every 10 seconds if everything is fine and signals are received correctly.
-
-To terminate manually, press the push button for at least 10 seconds until LED turns on. (The LED will also turn on if hcxdumptool terminates.)
-
-Afterwards, the Raspberry Pi can be turned off and disconnected from it's power supply.
-
-PCAPNG Option Codes (Section Header Block)
--------------------------------------------
+### PCAPNG Option Codes (Section Header Block)
 
 ENTERPRISE NUMBER: 0x2a, 0xce, 0x46, 0xa1
 
@@ -230,8 +212,7 @@ OPTIONCODE_WEAKCANDIDATE: 0xf2a0 (64 byte) == 63 characters + zero
 
 OPTIONCODE_GPS: 0xf2a1 (max 128 byte)
 
-Warning!
----------
+### Warning!
 
 You might expect me to recommend that everyone should be using hcxdumptool/hcxtools. But the fact of the matter is, hcxdumptool/hcxtools is NOT recommended to be used by inexperienced users or newbies.
 
@@ -250,55 +231,54 @@ The BPF can be used to select a target (or multible targets) or to protect devic
 
 By default options hcxdumptool is running three attack vectors:
 
-* connect to an ACCESS POINT to get a PMKID (turn off by --attemptapmax)
+- connect to an ACCESS POINT to get a PMKID (turn off by --attemptapmax)
 
-* disconnect a CLIENT from an associated ACCESS POINT to get a complete handshake (M1M2M3M4) and a PMKID (turn off by --attemptapmax)
+- disconnect a CLIENT from an associated ACCESS POINT to get a complete handshake (M1M2M3M4) and a PMKID (turn off by --attemptapmax)
 
-* allow a CLIENT to connect to hcxdumptool to get a challenge (M1M2) or an EAP-ID (turn off by --attemptclientmax)
+- allow a CLIENT to connect to hcxdumptool to get a challenge (M1M2) or an EAP-ID (turn off by --attemptclientmax)
 
 You must use hcxdumptool only on networks you have permission to do this and if you know what you are doing, because:
 
-* hcxdumptool is able to prevent complete WLAN traffic transmission. (Depending on selected options.)
+- hcxdumptool is able to prevent complete WLAN traffic transmission. (Depending on selected options.)
 
-* hcxdumptool is able to capture PMKIDs from access points. (Only one single PMKID from an access point is required. Use hcxpcapngtool to convert them to a format Hashcat or JtR understands.)
+- hcxdumptool is able to capture PMKIDs from access points. (Only one single PMKID from an access point is required. Use hcxpcapngtool to convert them to a format Hashcat or JtR understands.)
 
-* hcxdumptool is able to capture handshakes from non-connected clients. (Only one single M2 from the client is required. Use hcxpcapngtool to convert them to a format Hashcat or JtR understands.)
+- hcxdumptool is able to capture handshakes from non-connected clients. (Only one single M2 from the client is required. Use hcxpcapngtool to convert them to a format Hashcat or JtR understands.)
 
-* hcxdumptool is able to capture handshakes from 5/6GHz clients on 2.4GHz. (Only one single M2 from the client is required. Use hcxpcapngtool to to a format Hashcat or JtR understands.)
+- hcxdumptool is able to capture handshakes from 5/6GHz clients on 2.4GHz. (Only one single M2 from the client is required. Use hcxpcapngtool to to a format Hashcat or JtR understands.)
 
-* hcxdumptool is able to capture passwords from the WLAN traffic. (Use hcxpcapngtool -R to save them to file, or together with networknames [-E].)
+- hcxdumptool is able to capture passwords from the WLAN traffic. (Use hcxpcapngtool -R to save them to file, or together with networknames [-E].)
 
-* hcxdumptool is able to request and capture extended EAPOL (RADIUS, GSM-SIM, WPS. hcxpcapngtool will show you information about them.)
+- hcxdumptool is able to request and capture extended EAPOL (RADIUS, GSM-SIM, WPS. hcxpcapngtool will show you information about them.)
 
-* hcxdumptool is able to capture identities from the WLAN traffic. (Example: Request IMSI numbers from mobile phones - use hcxpcapngtool -I to save them to file.)
+- hcxdumptool is able to capture identities from the WLAN traffic. (Example: Request IMSI numbers from mobile phones - use hcxpcapngtool -I to save them to file.)
 
-* hcxdumptool is able to capture usernames from the WLAN traffic. (Example: User name of a server authentication - use hcxpcapngtool -U to save them to file.)
+- hcxdumptool is able to capture usernames from the WLAN traffic. (Example: User name of a server authentication - use hcxpcapngtool -U to save them to file.)
 
-* Do not use a logical interface and leave the physical interface in managed mode!
+- Do not use a logical interface and leave the physical interface in managed mode!
 
-* Do not use hcxdumptool in combination with the aircrack-ng suite, Reaver, Bully or other tools which take access to the interface!
+- Do not use hcxdumptool in combination with the aircrack-ng suite, Reaver, Bully or other tools which take access to the interface!
 
-* Stop all services which take access to the physical interface! (NetworkManager, wpa_supplicant,...)
+- Stop all services which take access to the physical interface! (NetworkManager, wpa_supplicant,...)
 
-* Do not use tools like macchanger as they are useless since hcxdumptool uses its own random MAC address space.
+- Do not use tools like macchanger as they are useless since hcxdumptool uses its own random MAC address space.
 
-* Do not merge PCAPNG dumpfiles because that will destroy custom block hash assignments!
+- Do not merge PCAPNG dumpfiles because that will destroy custom block hash assignments!
 
-* Capture format PCAPNG is compatible with Wireshark and tshark.
+- Capture format PCAPNG is compatible with Wireshark and tshark.
 
-Useful Links
--------------
+### Useful Links
 
-* PCAPNG Format Information - https://pcapng.com/
+- PCAPNG Format Information - https://pcapng.com/
 
-* The Linux Kernel Documentation - https://www.kernel.org/doc/html/latest/
+- The Linux Kernel Documentation - https://www.kernel.org/doc/html/latest/
 
-* BPF Documentation - https://www.kernel.org/doc/html/latest/bpf/index.html
+- BPF Documentation - https://www.kernel.org/doc/html/latest/bpf/index.html
 
-* Linux Commands Handbook - https://www.freecodecamp.org/news/the-linux-commands-handbook/
+- Linux Commands Handbook - https://www.freecodecamp.org/news/the-linux-commands-handbook/
 
-* WPA2 Information - https://en.wikipedia.org/wiki/Wpa2
+- WPA2 Information - https://en.wikipedia.org/wiki/Wpa2
 
-* 802.11 Frame Types - https://en.wikipedia.org/wiki/802.11_Frame_Types
+- 802.11 Frame Types - https://en.wikipedia.org/wiki/802.11_Frame_Types
 
-* 802.11 Security Improvements - https://en.wikipedia.org/wiki/IEEE_802.11i-2004
+- 802.11 Security Improvements - https://en.wikipedia.org/wiki/IEEE_802.11i-2004

--- a/docs/hardware-mod.md
+++ b/docs/hardware-mod.md
@@ -1,0 +1,7 @@
+# Hardware Modification - See /docs For More Info
+
+When using this hardware modification, the LED will flash every 10 seconds if everything is fine and signals are received correctly.
+
+To terminate manually, press the push button for at least 10 seconds until LED turns on. (The LED will also turn on if hcxdumptool terminates.)
+
+Afterwards, the Raspberry Pi can be turned off and disconnected from it's power supply.


### PR DESCRIPTION
The style changes were done for easier reading and comprehension. The removal of the **hardware mod** section was to improve reading flow as it felt out of place in the main README. The section was preserved however as it is now located at /docs/hardware-mod.md